### PR TITLE
chore: Update project name

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,4 @@
-# Q-CTRL Python Open Controls
+# Q-CTRL Open Controls
 
 Q-CTRL Open Controls is an open-source Python package that makes it easy to
 create and deploy established error-robust quantum control protocols from the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "qctrl-open-controls"
 version = "10.0.0"
-description = "Q-CTRL Python Open Controls"
+description = "Q-CTRL Open Controls"
 license = "Apache-2.0"
 authors = ["Q-CTRL <support@q-ctrl.com>"]
 maintainers = ["Q-CTRL <support@q-ctrl.com>"]
 readme = "README.md"
 homepage = "https://q-ctrl.com"
-repository = "https://github.com/qctrl/python-open-controls"
+repository = "https://github.com/qctrl/open-controls"
 documentation = "https://docs.q-ctrl.com/open-controls/references/qctrl-open-controls/"
 keywords = [
     "black opal",


### PR DESCRIPTION
A few things I missed #274 . Mainly, that without "python" in the name of the repo, the project name should now be "Q-CTRL Open Controls" rather than "Q-CTRL Python Open Controls".

Changes proposed in this pull request:
- Update project name to "Q-CTRL Open Controls".
- Update repo name in `pyproject.toml`.