### PR TITLE
build: Remove legacy code from docs/conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,22 +48,6 @@ author = ", ".join(package_info["authors"])
 release = package_info["version"]
 copyright = f"{datetime.datetime.now().year} Q-CTRL. All rights reserved."  # pylint: disable=redefined-builtin
 
-# -- HTML Variables ----------------------------------------------------------
-# Variables to insert into _templates/layout.html
-# Taken from qctrl/docs, see head.html in the repo
-html_context = {
-    "var_url": "https://docs.q-ctrl.com",
-    "var_title": "Open Controls Python package | Q-CTRL",
-    "var_description": (
-        "Module, class, and method reference for the Q-CTRL Open Controls Python package"
-    ),
-    "var_image": (
-        "https://images.ctfassets.net/l5sdcktfe9p6/6XwDBOS4cWBv2Lo"
-        "SimZwKj/1fb29e7c1e2941114d5eda81797e84ac/q-ctrl.jpg"
-    ),
-    "var_twitter_username": "qctrlHQ",
-}
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -95,8 +79,6 @@ exclude_patterns: List[str] = []
 # a list of builtin themes.
 #
 html_theme = "qctrl_sphinx_theme"
-
-html_title = html_context["var_title"]
 
 # Theme options
 html_theme_options = {


### PR DESCRIPTION
There's some legacy code in the file `docs/conf.py` that is no longer necessary to build the reference docs.

As can be seen from the code comment, these were variables to be inserted in the file `_templates/layout.html`, which is no longer present in this repo.

(I removed that file as part of #254, but didn't realize that the new `_templates/layout.html` file from the Q-CTRL Sphinx Theme doesn't need any of those variables.)

Changes proposed in this pull request:
- Remove legacy code from `docs/conf.py`.