### PR TITLE
ci: Remove docs update step on release

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -27,16 +27,3 @@ jobs:
       - name: Publish internally
         run: |
           ./ci docker run qctrl/ci-images:python-3.11-ci /scripts/publish-release-internally.sh
-
-  update_documentation:
-    if: false # This job is disabled until https://qctrl.atlassian.net/browse/ACC-386 is resolved
-    runs-on: ubuntu-latest
-    container: qctrl/ci-images:python-3.11-ci
-    steps:
-      - name: Update docs repo
-        uses: qctrl/reusable-workflows/.github/actions/docs/update-docs@master
-        with:
-          source_branch: master
-          target_branch: master
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
Addresses: https://qctrl.atlassian.net/browse/ACC-562

Changes proposed in this pull request:

- Remove docs update step on release
