### PR TITLE
fix: Update mathematical notation for consistency in predefined.py

### DIFF
--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -192,10 +192,14 @@ def new_bb1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
-       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+3\phi_*`,:math:`0`
-       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi`, :math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+3\phi_*`,:math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\phi_*`, :math:`0`
 
     where
 
@@ -273,9 +277,12 @@ def new_sk1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi-\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi-\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\phi_*`, :math:`0`
 
     where
 
@@ -352,17 +359,22 @@ def new_scrofulous_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_\mathrm{max}`, :math:`\phi+\phi_1`, :math:`0`
-       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_2`, :math:`0`
-       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_3`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_\mathrm{max}`,
+       :math:`\phi+\phi_1`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\phi_2`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\phi_3`, :math:`0`
 
     where
 
     .. math::
         \begin{align}
-        \theta_1 &= \theta_3 = \mathrm{sinc}^{-1} \left[\frac{2\cos (\theta/2)}{\pi}\right] \\
+        \theta_1 &=
+        \theta_3 = \mathrm{sinc}^{-1} \left[\frac{2\cos (\theta/2)}{\pi}\right] \\
         \theta_2 &= \pi \\
-        \phi_1 &= \phi_3 = \cos^{-1}\left[ \frac{-\pi\cos(\theta_1)}{2\theta_1\sin(\theta/2)}\right] \\
+        \phi_1 &=
+        \phi_3 = \cos^{-1}\left[ \frac{-\pi\cos(\theta_1)}{2\theta_1\sin(\theta/2)}\right] \\
         \phi_2 &= \phi_1 - \cos^{-1} \left(-\frac{\pi}{2\theta_1}\right)
         \end{align}
 
@@ -466,9 +478,12 @@ def new_corpse_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
-       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\pi`, :math:`0`
-       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\pi`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi`, :math:`0`
 
     where
 
@@ -557,12 +572,18 @@ def new_corpse_in_bb1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
-       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\pi`, :math:`0`
-       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
-       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+3\phi_*`, :math:`0`
-       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\pi`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi`, :math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+3\phi_*`, :math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\phi_*`, :math:`0`
 
     where
 
@@ -663,11 +684,16 @@ def new_corpse_in_sk1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
-       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\pi`, :math:`0`
-       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi-\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\pi`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi-\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
+       :math:`\phi+\phi_*`, :math:`0`
 
     where
 

--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -829,8 +829,10 @@ def new_corpse_in_scrofulous_control(
 
     .. math::
         \begin{align}
-        \Gamma^{\theta'}_1 &= 2\pi + \frac{\theta'}{2} - \sin^{-1} \left[ \frac{\sin(\theta'/2)}{2}\right] \\
-        \Gamma^{\theta'}_2 &= 2\pi - 2\sin^{-1} \left[ \frac{\sin(\theta'/2)}{2}\right] \\
+        \Gamma^{\theta'}_1 &=
+        2\pi + \frac{\theta'}{2} - \sin^{-1} \left[ \frac{\sin(\theta'/2)}{2}\right] \\
+        \Gamma^{\theta'}_2 &=
+        2\pi - 2\sin^{-1} \left[ \frac{\sin(\theta'/2)}{2}\right] \\
         \Gamma^{\theta'}_3 &= \frac{\theta'}{2} - \sin^{-1} \left[ \frac{\sin(\theta'/2)}{2}\right]
         \end{align}
 

--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -288,7 +288,7 @@ def new_sk1_control(
         <https://doi.org/10.1103/PhysRevA.70.052318>`_
     .. [#] `K. R. Brown, A. W. Harrow, and I. L. Chuang, Physical Review A 72, 039905 (2005).
         <https://doi.org/10.1103/PhysRevA.72.039905>`_
-    """
+    """  # pylint: disable=line-too-long
 
     _validate_rabi_parameters(
         rabi_rotation=rabi_rotation, maximum_rabi_rate=maximum_rabi_rate
@@ -374,7 +374,7 @@ def new_scrofulous_control(
     ----------
     .. [#] `H. K. Cummins, G. Llewellyn, and J. A. Jones, Physical Review A 67, 042308 (2003).
         <https://doi.org/10.1103/PhysRevA.67.042308>`_
-    """
+    """  # pylint: disable=line-too-long
 
     _validate_rabi_parameters(
         rabi_rotation=rabi_rotation, maximum_rabi_rate=maximum_rabi_rate
@@ -488,7 +488,7 @@ def new_corpse_control(
         <https://doi.org/10.1088/1367-2630/2/1/006>`_
     .. [#] `H. K. Cummins, G. Llewellyn, and J. A. Jones, Physical Review A 67, 042308 (2003).
         <https://doi.org/10.1103/PhysRevA.67.042308>`_
-    """
+    """  # pylint: disable=line-too-long
 
     _validate_rabi_parameters(
         rabi_rotation=rabi_rotation, maximum_rabi_rate=maximum_rabi_rate
@@ -582,7 +582,7 @@ def new_corpse_in_bb1_control(
         Japan 82, 1 (2012). <https://doi.org/10.7566/JPSJ.82.014004>`_
     .. [#] `C. Kabytayev, T. J. Green, K. Khodjasteh, M. J. Biercuk, L. Viola, and K. R. Brown,
         Physical Review A 90, 012316 (2014). <https://doi.org/10.1103/PhysRevA.90.012316>`_
-    """
+    """  # pylint: disable=line-too-long
 
     _validate_rabi_parameters(
         rabi_rotation=rabi_rotation, maximum_rabi_rate=maximum_rabi_rate
@@ -687,7 +687,7 @@ def new_corpse_in_sk1_control(
         Japan 82, 1 (2012). <https://doi.org/10.7566/JPSJ.82.014004>`_
     .. [#] `C. Kabytayev, T. J. Green, K. Khodjasteh, M. J. Biercuk, L. Viola, and K. R. Brown,
         Physical Review A 90, 012316 (2014). <https://doi.org/10.1103/PhysRevA.90.012316>`_
-    """
+    """  # pylint: disable=line-too-long
 
     _validate_rabi_parameters(
         rabi_rotation=rabi_rotation, maximum_rabi_rate=maximum_rabi_rate

--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -123,7 +123,7 @@ def new_primitive_control(
     rabi_rotation : float
         The total Rabi rotation :math:`\theta` to be performed by the driven control.
     maximum_rabi_rate : float
-        The maximum Rabi frequency :math:`\Omega_{\rm max}` for the driven control.
+        The maximum Rabi frequency :math:`\Omega_{\mathrm max}` for the driven control.
     azimuthal_angle : float, optional
         The azimuthal angle :math:`\phi` for the rotation. Defaults to 0.
     name : str, optional
@@ -141,7 +141,7 @@ def new_primitive_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
     """
 
     _validate_rabi_parameters(
@@ -174,7 +174,7 @@ def new_bb1_control(
     rabi_rotation : float
         The total Rabi rotation :math:`\theta` to be performed by the driven control.
     maximum_rabi_rate : float
-        The maximum Rabi frequency :math:`\Omega_{\rm max}` for the driven control.
+        The maximum Rabi frequency :math:`\Omega_{\mathrm max}` for the driven control.
     azimuthal_angle : float, optional
         The azimuthal angle :math:`\phi` for the rotation. Defaults to 0.
     name : str, optional
@@ -192,10 +192,10 @@ def new_bb1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
-       :math:`\pi/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+3\phi_*`,:math:`0`
-       :math:`\pi/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+3\phi_*`,:math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
 
     where
 
@@ -255,7 +255,7 @@ def new_sk1_control(
     rabi_rotation : float
         The total Rabi rotation :math:`\theta` to be performed by the driven control.
     maximum_rabi_rate : float
-        The maximum Rabi frequency :math:`\Omega_{\rm max}` for the driven control.
+        The maximum Rabi frequency :math:`\Omega_{\mathrm max}` for the driven control.
     azimuthal_angle : float, optional
         The azimuthal angle :math:`\phi` for the rotation. Defaults to 0.
     name : str, optional
@@ -273,9 +273,9 @@ def new_sk1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
-       :math:`2\pi/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi-\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi-\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
 
     where
 
@@ -334,7 +334,7 @@ def new_scrofulous_control(
         The total Rabi rotation :math:`\theta` to be performed by the driven control. Must be either
         :math:`\pi/4`, :math:`\pi/2`, or :math:`\pi`.
     maximum_rabi_rate : float
-        The maximum Rabi frequency :math:`\Omega_{\rm max}` for the driven control.
+        The maximum Rabi frequency :math:`\Omega_{\mathrm max}` for the driven control.
     azimuthal_angle : float, optional
         The azimuthal angle :math:`\phi` for the rotation. Defaults to 0.
     name : str, optional
@@ -352,20 +352,19 @@ def new_scrofulous_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\rm max}`, :math:`\Omega_\rm{max}`, :math:`\phi+\phi_1`, :math:`0`
-       :math:`\theta_2/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\phi_2`, :math:`0`
-       :math:`\theta_3/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\phi_3`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_\mathrm{max}`, :math:`\phi+\phi_1`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_2`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_3`, :math:`0`
 
     where
 
     .. math::
-        \theta_1 &= \theta_3 = \mathrm{sinc}^{-1} \left[\frac{2\cos (\theta/2)}{\pi}\right]
-
-        \theta_2 &= \pi
-
-        \phi_1 &= \phi_3 = \cos^{-1}\left[ \frac{-\pi\cos(\theta_1)}{2\theta_1\sin(\theta/2)}\right]
-
-        \phi_2 &= \phi_1 - \cos^{-1} (-\pi/2\theta_1),
+        \begin{align}
+        \theta_1 &= \theta_3 = \mathrm{sinc}^{-1} \left[\frac{2\cos (\theta/2)}{\pi}\right] \\
+        \theta_2 &= \pi \\
+        \phi_1 &= \phi_3 = \cos^{-1}\left[ \frac{-\pi\cos(\theta_1)}{2\theta_1\sin(\theta/2)}\right] \\
+        \phi_2 &= \phi_1 - \cos^{-1} \left(-\frac{\pi}{2\theta_1}\right)
+        \end{align}
 
     and :math:`\mathrm{sinc}(x)=\sin(x)/x` is the unnormalized sinc function.
 
@@ -449,7 +448,7 @@ def new_corpse_control(
     rabi_rotation : float
         The total Rabi rotation :math:`\theta` to be performed by the driven control.
     maximum_rabi_rate : float
-        The maximum Rabi frequency :math:`\Omega_{\rm max}` for the driven control.
+        The maximum Rabi frequency :math:`\Omega_{\mathrm max}` for the driven control.
     azimuthal_angle : float, optional
         The azimuthal angle :math:`\phi` for the rotation. Defaults to 0.
     name : str, optional
@@ -467,18 +466,19 @@ def new_corpse_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
-       :math:`\theta_2/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\pi`, :math:`0`
-       :math:`\theta_3/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\pi`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
 
     where
 
     .. math::
-        \theta_1 &= 2\pi + \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right]
+        \begin{align}
+        \theta_1 &= 2\pi + \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right] \\
+        \theta_2 &= 2\pi - 2\sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right] \\
+        \theta_3 &= \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right]
+        \end{align}
 
-        \theta_2 &= 2\pi - 2\sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right]
-
-        \theta_3 &= \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right].
 
     References
     ----------
@@ -534,7 +534,7 @@ def new_corpse_in_bb1_control(
     rabi_rotation : float
         The total Rabi rotation :math:`\theta` to be performed by the driven control.
     maximum_rabi_rate : float
-        The maximum Rabi frequency :math:`\Omega_{\rm max}` for the driven control.
+        The maximum Rabi frequency :math:`\Omega_{\mathrm max}` for the driven control.
     azimuthal_angle : float, optional
         The azimuthal angle :math:`\phi` for the rotation. Defaults to 0.
     name : str, optional
@@ -557,23 +557,22 @@ def new_corpse_in_bb1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
-       :math:`\theta_2/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\pi`, :math:`0`
-       :math:`\theta_3/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
-       :math:`\pi/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+3\phi_*`, :math:`0`
-       :math:`\pi/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\pi`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+3\phi_*`, :math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
 
     where
 
     .. math::
-        \theta_1 &= 2\pi + \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right]
-
-        \theta_2 &= 2\pi - 2\sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right]
-
-        \theta_3 &= \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right]
-
-        \phi_* &= \cos^{-1} \left( -\frac{\theta}{4\pi} \right).
+        \begin{align}
+        \theta_1 &= 2\pi + \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right] \\
+        \theta_2 &= 2\pi - 2\sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right] \\
+        \theta_3 &= \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right] \\
+        \phi_* &= \cos^{-1} \left( -\frac{\theta}{4\pi} \right)
+        \end{align}
 
     References
     ----------
@@ -641,7 +640,7 @@ def new_corpse_in_sk1_control(
     rabi_rotation : float
         The total Rabi rotation :math:`\theta` to be performed by the driven control.
     maximum_rabi_rate : float
-        The maximum Rabi frequency :math:`\Omega_{\rm max}` for the driven control.
+        The maximum Rabi frequency :math:`\Omega_{\mathrm max}` for the driven control.
     azimuthal_angle : float, optional
         The azimuthal angle :math:`\phi` for the rotation. Defaults to 0.
     name : str, optional
@@ -664,22 +663,21 @@ def new_corpse_in_sk1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
-       :math:`\theta_2/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\pi`, :math:`0`
-       :math:`\theta_3/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
-       :math:`2\pi/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi-\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\pi`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi-\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
 
     where
 
     .. math::
-        \theta_1 &= 2\pi + \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right]
-
-        \theta_2 &= 2\pi - 2\sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right]
-
-        \theta_3 &= \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right]
-
-        \phi_* &= \cos^{-1} \left( -\frac{\theta}{4\pi} \right).
+        \begin{align}
+        \theta_1 &= 2\pi + \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right] \\
+        \theta_2 &= 2\pi - 2\sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right] \\
+        \theta_3 &= \frac{\theta}{2} - \sin^{-1} \left[ \frac{\sin(\theta/2)}{2}\right] \\
+        \phi_* &= \cos^{-1} \left( -\frac{\theta}{4\pi} \right)
+        \end{align}
 
     References
     ----------
@@ -746,7 +744,7 @@ def new_corpse_in_scrofulous_control(
         The total Rabi rotation :math:`\theta` to be performed by the driven control. Must be either
         :math:`\pi/4`, :math:`\pi/2`, or :math:`\pi`.
     maximum_rabi_rate : float
-        The maximum Rabi frequency :math:`\Omega_{\rm max}` for the driven control.
+        The maximum Rabi frequency :math:`\Omega_{\mathrm max}` for the driven control.
     azimuthal_angle : float, optional
         The azimuthal angle :math:`\phi` for the rotation. Defaults to 0.
     name : str, optional
@@ -769,46 +767,44 @@ def new_corpse_in_scrofulous_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\Gamma^{\theta_1}_1/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, "
+       :math:`\Gamma^{\theta_1}_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, "
        :math:`\phi+\phi_1`", :math:`0`
-       :math:`\Gamma^{\theta_1}_2/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, "
+       :math:`\Gamma^{\theta_1}_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, "
        :math:`\phi+\phi_1+\pi`", :math:`0`
-       :math:`\Gamma^{\theta_1}_3/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, "
+       :math:`\Gamma^{\theta_1}_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, "
        :math:`\phi+\phi_1`", :math:`0`
-       :math:`\Gamma^{\theta_2}_1/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, "
+       :math:`\Gamma^{\theta_2}_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, "
        :math:`\phi+\phi_2`", :math:`0`
-       :math:`\Gamma^{\theta_2}_2/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, "
+       :math:`\Gamma^{\theta_2}_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, "
        :math:`\phi+\phi_2+\pi`", :math:`0`
-       :math:`\Gamma^{\theta_2}_3/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, "
+       :math:`\Gamma^{\theta_2}_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, "
        :math:`\phi+\phi_2`", :math:`0`
-       :math:`\Gamma^{\theta_3}_1/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, "
+       :math:`\Gamma^{\theta_3}_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, "
        :math:`\phi+\phi_3`", :math:`0`
-       :math:`\Gamma^{\theta_3}_2/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, "
+       :math:`\Gamma^{\theta_3}_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, "
        :math:`\phi+\phi_3+\pi`", :math:`0`
-       :math:`\Gamma^{\theta_3}_3/\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, "
+       :math:`\Gamma^{\theta_3}_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, "
        :math:`\phi+\phi_3`", :math:`0`
 
     where
 
     .. math::
-        \theta_1 &= \theta_3 = \mathrm{sinc}^{-1} \left[\frac{2\cos (\theta/2)}{\pi}\right]
-
-        \theta_2 &= \pi
-
-        \phi_1 &= \phi_3 = \cos^{-1}\left[ \frac{-\pi\cos(\theta_1)}{2\theta_1\sin(\theta/2)}\right]
-
-        \phi_2 &= \phi_1 - \cos^{-1} (-\pi/2\theta_1)
+        \begin{align}
+        \theta_1 &= \theta_3 = \mathrm{sinc}^{-1} \left[\frac{2\cos (\theta/2)}{\pi}\right] \\
+        \theta_2 &= \pi \\
+        \phi_1 &= \phi_3 = \cos^{-1}\left[ \frac{-\pi\cos(\theta_1)}{2\theta_1\sin(\theta/2)}\right] \\
+        \phi_2 &= \phi_1 - \cos^{-1} \left(-\frac{\pi}{2\theta_1}\right)
+        \end{align}
 
     (with :math:`\mathrm{sinc}(x)=\sin(x)/x` the unnormalized sinc function) are the SCROFULOUS
     angles, and
 
     .. math::
-        \Gamma^{\theta'}_1 &= 2\pi + \frac{\theta'}{2}
-            - \sin^{-1} \left[ \frac{\sin(\theta'/2)}{2}\right]
-
-        \Gamma^{\theta'}_2 &= 2\pi - 2\sin^{-1} \left[ \frac{\sin(\theta'/2)}{2}\right]
-
+        \begin{align}
+        \Gamma^{\theta'}_1 &= 2\pi + \frac{\theta'}{2} - \sin^{-1} \left[ \frac{\sin(\theta'/2)}{2}\right] \\
+        \Gamma^{\theta'}_2 &= 2\pi - 2\sin^{-1} \left[ \frac{\sin(\theta'/2)}{2}\right] \\
         \Gamma^{\theta'}_3 &= \frac{\theta'}{2} - \sin^{-1} \left[ \frac{\sin(\theta'/2)}{2}\right]
+        \end{align}
 
     are the CORPSE angles corresponding to each SCROFULOUS angle
     :math:`\theta'\in\{\theta_1,\theta_2,\theta_3\}`.
@@ -905,7 +901,7 @@ def new_wamf1_control(
         The total Rabi rotation :math:`\theta` to be performed by the driven control. Must be either
         :math:`\pi/4`, :math:`\pi/2`, or :math:`\pi`.
     maximum_rabi_rate : float
-        The maximum Rabi frequency :math:`\Omega_{\rm max}` for the driven control.
+        The maximum Rabi frequency :math:`\Omega_{\mathrm max}` for the driven control.
     azimuthal_angle : float, optional
         The azimuthal angle :math:`\phi` for the rotation. Defaults to 0.
     name : str, optional
@@ -923,12 +919,12 @@ def new_wamf1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_+/4\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
-       :math:`\theta_+/4\Omega_{\rm max}`, :math:`\Omega_{\rm max}\theta_-/\theta_+`,"
+       :math:`\theta_+/4\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta_+/4\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}\theta_-/\theta_+`,"
        :math:`\phi`", :math:`0`
-       :math:`\theta_+/4\Omega_{\rm max}`, :math:`\Omega_{\rm max}\theta_-/\theta_+`, "
+       :math:`\theta_+/4\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}\theta_-/\theta_+`, "
        :math:`\phi`", :math:`0`
-       :math:`\theta_+/4\Omega_{\rm max}`, :math:`\Omega_{\rm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta_+/4\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
 
     where :math:`\theta_\pm = \theta+2\pi k_\theta\pm \delta_\theta`, and the integer
     :math:`k_\theta` and offset :math:`\delta_\theta` are optimized numerically in order to maximize

--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -816,9 +816,11 @@ def new_corpse_in_scrofulous_control(
 
     .. math::
         \begin{align}
-        \theta_1 &= \theta_3 = \mathrm{sinc}^{-1} \left[\frac{2\cos (\theta/2)}{\pi}\right] \\
+        \theta_1 &=
+        \theta_3 = \mathrm{sinc}^{-1} \left[\frac{2\cos (\theta/2)}{\pi}\right] \\
         \theta_2 &= \pi \\
-        \phi_1 &= \phi_3 = \cos^{-1}\left[ \frac{-\pi\cos(\theta_1)}{2\theta_1\sin(\theta/2)}\right] \\
+        \phi_1 &= \phi_3 =
+        \cos^{-1}\left[ \frac{-\pi\cos(\theta_1)}{2\theta_1\sin(\theta/2)}\right] \\
         \phi_2 &= \phi_1 - \cos^{-1} \left(-\frac{\pi}{2\theta_1}\right)
         \end{align}
 

--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -192,14 +192,10 @@ def new_bb1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi`, :math:`0`
-       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+3\phi_*`,:math:`0`
-       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+3\phi_*`,:math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
 
     where
 
@@ -277,12 +273,9 @@ def new_sk1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi-\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi-\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
 
     where
 
@@ -359,12 +352,9 @@ def new_scrofulous_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_\mathrm{max}`,
-       :math:`\phi+\phi_1`, :math:`0`
-       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\phi_2`, :math:`0`
-       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\phi_3`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_\mathrm{max}`, :math:`\phi+\phi_1`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_2`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_3`, :math:`0`
 
     where
 
@@ -478,12 +468,9 @@ def new_corpse_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi`, :math:`0`
-       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\pi`, :math:`0`
-       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\pi`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
 
     where
 
@@ -572,18 +559,12 @@ def new_corpse_in_bb1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi`, :math:`0`
-       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\pi`, :math:`0`
-       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi`, :math:`0`
-       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+3\phi_*`, :math:`0`
-       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\pi`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+3\phi_*`, :math:`0`
+       :math:`\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
 
     where
 
@@ -684,16 +665,11 @@ def new_corpse_in_sk1_control(
     .. csv-table::
        :header: :math:`\\delta t_n`, :math:`\\Omega_n`, :math:`\\phi_n` , :math:`\\Delta_n`
 
-       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi`, :math:`0`
-       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\pi`, :math:`0`
-       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi-\phi_*`, :math:`0`
-       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`,
-       :math:`\phi+\phi_*`, :math:`0`
+       :math:`\theta_1/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`\theta_2/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\pi`, :math:`0`
+       :math:`\theta_3/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi-\phi_*`, :math:`0`
+       :math:`2\pi/\Omega_{\mathrm max}`, :math:`\Omega_{\mathrm max}`, :math:`\phi+\phi_*`, :math:`0`
 
     where
 

--- a/qctrlopencontrols/driven_controls/predefined.py
+++ b/qctrlopencontrols/driven_controls/predefined.py
@@ -206,7 +206,7 @@ def new_bb1_control(
     ----------
     .. [#] `S. Wimperis, Journal of Magnetic Resonance, Series A 109, 2 (1994).
         <https://doi.org/10.1006/jmra.1994.1159>`_
-    """
+    """  # pylint: disable=line-too-long
 
     _validate_rabi_parameters(
         rabi_rotation=rabi_rotation, maximum_rabi_rate=maximum_rabi_rate

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -614,14 +614,14 @@ def new_walsh_sequence(
     function [#]_, which is defined as
 
     .. math::
-        R_j(x) := {\rm sgn}\left[\sin(2^j \pi x)\right] \;, \quad\; x \in [0, 1]\;, \; j \geq 0 \;.
+        R_j(x) := {\mathrm sgn}\left[\sin(2^j \pi x)\right] \;, \quad\; x \in [0, 1]\;, \; j \geq 0 \;.
 
     The :math:`j`-th Rademacher function :math:`R_j(x)` is thus a periodic square wave switching
     :math:`2^{j-1}` times between :math:`\pm 1` over the interval :math:`[0, 1]`. The Walsh
-    function of Paley order :math:`k` is denoted :math:`{\rm PAL}_k(x)` and defined as
+    function of Paley order :math:`k` is denoted :math:`{\mathrm PAL}_k(x)` and defined as
 
     .. math::
-        {\rm PAL}_k(x) = \Pi_{j = 1}^m R_j(x)^{b_j} \;, \quad\; x \in [0, 1] \;.
+        {\mathrm PAL}_k(x) = \Pi_{j = 1}^m R_j(x)^{b_j} \;, \quad\; x \in [0, 1] \;.
 
     where :math:`(b_m, b_{m-1}, \cdots, b_1)` is the binary representation of :math:`k`.
     That is
@@ -634,7 +634,7 @@ def new_walsh_sequence(
     The :math:`k`-th order Walsh sequence [#]_ is then defined by
 
     .. math::
-        y(t) = {\rm PAL}_k(t / \tau) \;
+        y(t) = {\mathrm PAL}_k(t / \tau) \;
 
     with offset times :math:`\{t_j / \tau\}` defined at the switching times of the Walsh function.
 

--- a/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
+++ b/qctrlopencontrols/dynamic_decoupling_sequences/predefined.py
@@ -614,7 +614,8 @@ def new_walsh_sequence(
     function [#]_, which is defined as
 
     .. math::
-        R_j(x) := {\mathrm sgn}\left[\sin(2^j \pi x)\right] \;, \quad\; x \in [0, 1]\;, \; j \geq 0 \;.
+        R_j(x) := {\mathrm sgn}\left[\sin(2^j \pi x)\right] \;,
+        \quad\; x \in [0, 1]\;, \; j \geq 0 \;.
 
     The :math:`j`-th Rademacher function :math:`R_j(x)` is thus a periodic square wave switching
     :math:`2^{j-1}` times between :math:`\pm 1` over the interval :math:`[0, 1]`. The Walsh


### PR DESCRIPTION
Addresses: https://qctrl.atlassian.net/browse/PA-2317

This pull request includes several changes to the `qctrlopencontrols` library, specifically within the `driven_controls` and `dynamic_decoupling_sequences` modules. The primary focus of these changes is to standardize the notation for the maximum Rabi frequency and improve the clarity of mathematical expressions.

Standardization of notation:

* Updated the notation for the maximum Rabi frequency from `\Omega_{\rm max}` to `\Omega_{\mathrm max}` in the `new_primitive_control`, `new_bb1_control`, `new_sk1_control`, `new_scrofulous_control`, `new_corpse_control`, `new_corpse_in_bb1_control`, `new_corpse_in_sk1_control`, `new_corpse_in_scrofulous_control`, and `new_wamf1_control` functions. [[1]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L126-R126) [[2]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L177-R177) [[3]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L258-R258) [[4]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L337-R337) [[5]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L452-R451) [[6]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L537-R537) [[7]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L644-R643) [[8]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L749-R747) [[9]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L908-R904)

Improvement of mathematical expressions:

* Corrected the LaTeX notation for the sinc function and other mathematical expressions in the `new_scrofulous_control`, `new_corpse_control`, `new_corpse_in_bb1_control`, `new_corpse_in_sk1_control`, and `new_corpse_in_scrofulous_control` functions. [[1]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L355-R367) [[2]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L470-L481) [[3]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L560-R575) [[4]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L667-R680) [[5]](diffhunk://#diff-9bdae4d63d549e8d2f220246a06c3cef2c281d96a44d2992c437d158a57b17f2L772-R807)
* Updated the Walsh function definition in the `new_walsh_sequence` function to use `\mathrm` for consistency.