### PR TITLE
ci: Add new on-pull-request workflow

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -11,45 +11,21 @@ on:
       - '*.*'
 
 jobs:
-  check-dependencies:
-    # Filter out Draft Pull Requests
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Ensure no development packages have been set
-        run: |
-          source <(curl -sL http://ci.q-ctrl.com)
-          ./ci docker run qctrl/ci-images:python-3.11-ci /scripts/check-for-internal-versions.sh
-  linting:
-    # Filter out PRs originating from this repository (triggers on-push.yml instead)
-    if: github.event.pull_request.head.repo.fork == true
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install Python dependencies
-      run: |
-        source <(curl -sL http://ci.q-ctrl.com)
-        ./ci docker run qctrl/ci-images:python-3.11-ci /scripts/install-python-dependencies.sh
-    - name: Run Pre-Commit
-      run: |
-        ./ci docker run qctrl/ci-images:python-3.11-ci poetry run pre-commit run -- -a
+  pre-checks:
+    uses: qctrl/reusable-workflows/.github/workflows/poetry-pre-checks.yaml@master
+    secrets: inherit
+    with:
+      check-internal-versions: true
+      housekeeping: false
+
   pytest:
     # Filter out PRs originating from this repository (triggers on-push.yml instead)
     if: github.event.pull_request.head.repo.fork == true
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: ["3.9", "3.10", "3.11"]
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install Python dependencies
-      run: |
-        source <(curl -sL http://ci.q-ctrl.com)
-        ./ci docker run qctrl/ci-images:python-${{ matrix.python }}-ci /scripts/install-python-dependencies.sh
-    - name: Run Pytest
-      run: |
-        ./ci docker run qctrl/ci-images:python-${{ matrix.python }}-ci /scripts/pytest.sh
+    uses: qctrl/reusable-workflows/.github/workflows/pytest.yaml@master
+    secrets: inherit
+    with:
+      python-versions: '["3.9", "3.10", "3.11"]'
+
   sphinx_documentation:
     # Filter out PRs originating from this repository (triggers on-push.yml instead)
     if: github.event.pull_request.head.repo.fork == true


### PR DESCRIPTION
Updated CI workflow to use the latest pre-check on-pull-request resuseable workflow for checking internal versions.

This ensures consistency, improves automation, and makes it easier to manage any future changes.

Addresses: https://qctrl.atlassian.net/browse/INFRA-2128
