### PR TITLE
ci: Add docker build push docker workflow

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -34,8 +34,5 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build Sphinx Image
       run: |
-        source <(curl -sL http://ci.q-ctrl.com)
-        ./ci docker build \
-          -f ./docs/Dockerfile \
-          --suffix -docs
+        docker build -f ./docs/Dockerfile
 #################### Maintained by repositories-manager - do not edit directly ####################


### PR DESCRIPTION
Update the docker build ci workflow which now uses the installed `docker
build` command on the workflow runner.

This job only builds an image so there is no need to add a tag with the
suffix `-docs` this is mainly for testing the docker build runs without
any issues.