### PR TITLE
ci: Remove docker run commands and use container images in jobs instead

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -11,20 +11,58 @@ on:
       - '*.*'
 
 jobs:
-  pre-checks:
-    uses: qctrl/reusable-workflows/.github/workflows/poetry-pre-checks.yaml@master
-    secrets: inherit
-    with:
-      check-internal-versions: true
-      housekeeping: false
+  check-dependencies:
+    # Filter out Draft Pull Requests
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    container: qctrl/ci-images:python-3.11-ci
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download CI tool
+        shell: bash
+        run: |
+          curl -sSL http://ci.q-ctrl.com | bash -
+      - name: Ensure no development packages have been set
+        run: |
+          /scripts/check-for-internal-versions.sh
+  linting:
+    # Filter out PRs originating from this repository (triggers on-push.yml instead)
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    container: qctrl/ci-images:python-3.11-ci
+    steps:
+    - uses: actions/checkout@v4
+    - name: Download CI tool
+      shell: bash
+      run: |
+        curl -sSL http://ci.q-ctrl.com | bash -
+    - name: Install Python dependencies
+      run: |
+        /scripts/install-python-dependencies.sh
+    - name: Run Pre-Commit
+      run: |
+        poetry run pre-commit run -- -a
 
   pytest:
     # Filter out PRs originating from this repository (triggers on-push.yml instead)
     if: github.event.pull_request.head.repo.fork == true
-    uses: qctrl/reusable-workflows/.github/workflows/pytest.yaml@master
-    secrets: inherit
-    with:
-      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+    runs-on: ubuntu-latest
+    container: qctrl/ci-images:python-${{ matrix.python }}-ci
+    strategy:
+      matrix:
+        python: ["3.9", "3.10", "3.11"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Download CI tool
+      shell: bash
+      run: |
+        curl -sSL http://ci.q-ctrl.com | bash -
+    - name: Install Python dependencies
+      run: |
+        /scripts/install-python-dependencies.sh
+    - name: Run Pytest
+      run: |
+        /scripts/pytest.sh
 
   sphinx_documentation:
     # Filter out PRs originating from this repository (triggers on-push.yml instead)

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -24,6 +24,7 @@ jobs:
           curl -sSL http://ci.q-ctrl.com | bash -
       - name: Ensure no development packages have been set
         run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           /scripts/check-for-internal-versions.sh
   linting:
     # Filter out PRs originating from this repository (triggers on-push.yml instead)
@@ -38,6 +39,7 @@ jobs:
         curl -sSL http://ci.q-ctrl.com | bash -
     - name: Install Python dependencies
       run: |
+        git config --global --add safe.directory $GITHUB_WORKSPACE
         /scripts/install-python-dependencies.sh
     - name: Run Pre-Commit
       run: |
@@ -59,6 +61,7 @@ jobs:
         curl -sSL http://ci.q-ctrl.com | bash -
     - name: Install Python dependencies
       run: |
+        git config --global --add safe.directory $GITHUB_WORKSPACE
         /scripts/install-python-dependencies.sh
     - name: Run Pytest
       run: |

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Vault Login
         run: |
           ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
+      - name: Inject environment variables
+        run: |
+          /scripts/ci env prepareGitHub
       - name: Perform housekeeping checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,6 +85,9 @@ jobs:
       - name: Vault Login
         run: |
           ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
+      - name: Inject environment variables
+        run: |
+          /scripts/ci env prepareGitHub
       - name: Publish development version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -10,53 +10,76 @@ on:
 jobs:
   housekeeping:
     runs-on: ubuntu-latest
+    container: qctrl/ci-images:python-3.11-ci
     steps:
       - uses: actions/checkout@v4
+      - name: Download CI tool
+        shell: bash
+        run: |
+          curl -sSL http://ci.q-ctrl.com | bash -
+      - name: Vault Login
+        run: |
+          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
       - name: Perform housekeeping checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          source <(curl -sL http://ci.q-ctrl.com)
-          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
-          ./ci docker run qctrl/ci-images:python-3.11-ci /scripts/housekeeping.sh
+          /scripts/housekeeping.sh
 
   linting:
     runs-on: ubuntu-latest
+    container: qctrl/ci-images:python-3.11-ci
     steps:
       - uses: actions/checkout@v4
+      - name: Download CI tool
+        shell: bash
+        run: |
+          curl -sSL http://ci.q-ctrl.com | bash -
+      - name: Vault Login
+        run: |
+          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
       - name: Install Python dependencies
         run: |
-          source <(curl -sL http://ci.q-ctrl.com)
-          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
-          ./ci docker run qctrl/ci-images:python-3.11-ci /scripts/install-python-dependencies.sh
+          /scripts/install-python-dependencies.sh
       - name: Run Pre-Commit
         run: |
-          ./ci docker run qctrl/ci-images:python-3.11-ci poetry run pre-commit run -- -a
+          poetry run pre-commit run -- -a
 
   pytest:
     runs-on: ubuntu-latest
+    container: qctrl/ci-images:python-${{ matrix.python }}-ci
     strategy:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
+      - name: Download CI tool
+        shell: bash
+        run: |
+          curl -sSL http://ci.q-ctrl.com | bash -
+      - name: Vault Login
+        run: |
+          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
       - name: Install Python dependencies
         run: |
-          source <(curl -sL http://ci.q-ctrl.com)
-          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
-          ./ci docker run qctrl/ci-images:python-${{ matrix.python }}-ci /scripts/install-python-dependencies.sh
+          /scripts/install-python-dependencies.sh
       - name: Run Pytest
         run: |
-          ./ci docker run qctrl/ci-images:python-${{ matrix.python }}-ci /scripts/pytest.sh
+          /scripts/pytest.sh
 
   publish_internally:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Download CI tool
+        shell: bash
+        run: |
+          curl -sSL http://ci.q-ctrl.com | bash -
+      - name: Vault Login
+        run: |
+          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
       - name: Publish development version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          source <(curl -sL http://ci.q-ctrl.com)
-          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
-          ./ci docker run qctrl/ci-images:python-3.11-ci /scripts/publish-dev-version.sh
+          /scripts/publish-dev-version.sh

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -24,6 +24,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           /scripts/housekeeping.sh
 
   linting:
@@ -40,6 +41,7 @@ jobs:
           ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
       - name: Install Python dependencies
         run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           /scripts/install-python-dependencies.sh
       - name: Run Pre-Commit
         run: |
@@ -62,6 +64,7 @@ jobs:
           ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
       - name: Install Python dependencies
         run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           /scripts/install-python-dependencies.sh
       - name: Run Pytest
         run: |
@@ -69,6 +72,7 @@ jobs:
 
   publish_internally:
     runs-on: ubuntu-latest
+    container: qctrl/ci-images:python-3.11-ci
     steps:
       - uses: actions/checkout@v4
       - name: Download CI tool
@@ -82,4 +86,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           /scripts/publish-dev-version.sh

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -23,6 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           /scripts/housekeeping.sh
       - name: Publish publicly
         env:

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -7,26 +7,31 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    container: qctrl/ci-images:python-3.11-ci
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Download CI tool
+        shell: bash
+        run: |
+          curl -sSL http://ci.q-ctrl.com | bash -
+      - name: Vault Login
+        run: |
+          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
       - name: Update version in code
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          source <(curl -sL http://ci.q-ctrl.com)
-          ./ci vault login -r ${{ secrets.VAULT_ROLE_ID }} -s ${{ secrets.VAULT_SECRET_ID }}
-          ./ci docker run qctrl/ci-images:python-3.11-ci /scripts/housekeeping.sh
+          /scripts/housekeeping.sh
       - name: Publish publicly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          source <(curl -sL http://ci.q-ctrl.com)
-          ./ci docker run qctrl/ci-images:python-3.11-ci /scripts/publish-release-publicly.sh
+          /scripts/publish-release-publicly.sh
       - name: Publish internally
         run: |
-          ./ci docker run qctrl/ci-images:python-3.11-ci /scripts/publish-release-internally.sh
+          /scripts/publish-release-internally.sh
 
   update_documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change removes the `ci docker run ...` commands and uses the `container:` image name in the job instead, also please note that this repository is public and we cannot use our private org reusable workflows here due to restriction on private org reusable workflow repositories.