### PR TITLE
chore: Pin release workflow version

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -44,7 +44,7 @@ jobs:
     container: qctrl/ci-images:python-3.11-ci
     steps:
       - name: Update docs repo
-        uses: qctrl/reusable-workflows/.github/actions/docs/update-docs@master
+        uses: qctrl/reusable-workflows/.github/actions/docs/update-docs@actions/docs/update-docs/v1
         with:
           source_branch: master
           target_branch: master


### PR DESCRIPTION
Addresses: https://github.com/qctrl/reusable-workflows/pull/660#issuecomment-4786265319